### PR TITLE
Several improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
-  "name": "thegeekrv/i18n-routing-service-provider",
+  "name": "jenyak/i18n-routing-service-provider",
   "description": "Silex i18n routing service provider.",
   "keywords": ["silex", "i18n routing"],
   "license": "MIT",
   "require": {
-    "silex/silex": "~1.0@dev",
+    "silex/silex": "~2.0@dev",
     "symfony/translation": "~2.4"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
-  "name": "jenyak/i18n-routing-service-provider",
+  "name": "thegeekrv/i18n-routing-service-provider",
   "description": "Silex i18n routing service provider.",
   "keywords": ["silex", "i18n routing"],
   "license": "MIT",
   "require": {
-    "silex/silex": "~2.0@dev",
+    "silex/silex": "~1.0@dev",
     "symfony/translation": "~2.4"
   },
   "autoload": {

--- a/src/Jenyak/I18nRouting/I18nControllerCollection.php
+++ b/src/Jenyak/I18nRouting/I18nControllerCollection.php
@@ -78,6 +78,10 @@ class I18nControllerCollection extends ControllerCollection
                     $routes->add($name, $route);
                 } else {
                     foreach ($this->generateI18nPatterns($name, $route) as $pattern => $locales) {
+                        if($route->getOption('i18n_ignore') === true){
+                            $routes->add($name, $route);
+                            continue;
+                        }
                         // If this pattern is used for more than one locale, we need to keep the original route.
                         // We still add individual routes for each locale afterwards for faster generation.
                         if (count($locales) > 1) {

--- a/src/Jenyak/I18nRouting/I18nControllerCollection.php
+++ b/src/Jenyak/I18nRouting/I18nControllerCollection.php
@@ -38,11 +38,17 @@ class I18nControllerCollection extends ControllerCollection
                 $i18nPattern = $route->getPath();
             }
 
-            if ($this->defaultLocale == $locale && $this->localizedDefault === true) {
+            if($this->localizedDefault === true){
+                if ($this->defaultLocale == $locale ) {
+                    $patterns[$i18nPattern][] = $locale;
+                }
+                $patterns['/'.$locale.$i18nPattern][] = $locale;
+            }else{
+                if ($this->defaultLocale !== $locale) {
+                    $i18nPattern = '/'.$locale.$i18nPattern;
+                }
                 $patterns[$i18nPattern][] = $locale;
             }
-
-            $patterns['/'.$locale.$i18nPattern][] = $locale;
         }
 
         return $patterns;

--- a/src/Jenyak/I18nRouting/I18nControllerCollection.php
+++ b/src/Jenyak/I18nRouting/I18nControllerCollection.php
@@ -43,7 +43,6 @@ class I18nControllerCollection extends ControllerCollection
             }
 
             $patterns['/'.$locale.$i18nPattern][] = $locale;
-
         }
 
         return $patterns;

--- a/src/Jenyak/I18nRouting/I18nControllerCollection.php
+++ b/src/Jenyak/I18nRouting/I18nControllerCollection.php
@@ -16,13 +16,15 @@ class I18nControllerCollection extends ControllerCollection
     private $locales;
     private $translator;
     private $translationDomain;
+    private $localizedDefault;
 
-    public function __construct(Route $defaultRoute, $defaultLocale = 'en', array $locales, TranslatorInterface $translator, $translationDomain = 'routes')
+    public function __construct(Route $defaultRoute, $defaultLocale = 'en', array $locales, TranslatorInterface $translator, $translationDomain = 'routes', $localizedDefault = false)
     {
         $this->defaultLocale = $defaultLocale;
         $this->locales = $locales;
         $this->translator = $translator;
         $this->translationDomain = $translationDomain;
+        $this->localizedDefault = $localizedDefault;
 
         parent::__construct($defaultRoute);
     }
@@ -36,11 +38,12 @@ class I18nControllerCollection extends ControllerCollection
                 $i18nPattern = $route->getPath();
             }
 
-            if ($this->defaultLocale !== $locale) {
-                $i18nPattern = '/'.$locale.$i18nPattern;
+            if ($this->defaultLocale == $locale && $this->localizedDefault === true) {
+                $patterns[$i18nPattern][] = $locale;
             }
 
-            $patterns[$i18nPattern][] = $locale;
+            $patterns['/'.$locale.$i18nPattern][] = $locale;
+
         }
 
         return $patterns;
@@ -83,7 +86,8 @@ class I18nControllerCollection extends ControllerCollection
                             $localeRoute = clone $route;
                             $localeRoute->setPath($pattern);
                             $localeRoute->setDefault('_locale', $locale);
-                            $routes->add($locale.self::ROUTING_PREFIX.$name, $localeRoute);
+                            $default = (0 === strpos($pattern, '/'.$locale)) ? '' : '_default';
+                            $routes->add($locale.$default.self::ROUTING_PREFIX.$name, $localeRoute);
                         }
                     }
                 }

--- a/src/Jenyak/I18nRouting/Provider/I18nRoutingServiceProvider.php
+++ b/src/Jenyak/I18nRouting/Provider/I18nRoutingServiceProvider.php
@@ -4,12 +4,13 @@ namespace Jenyak\I18nRouting\Provider;
 
 use Jenyak\I18nRouting\I18nControllerCollection;
 use Jenyak\I18nRouting\I18nUrlGenerator;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
 use Silex\Application;
-use Silex\ServiceProviderInterface;
 
 class I18nRoutingServiceProvider implements ServiceProviderInterface
 {
-    public function register(Application $app)
+    public function register(Container $app)
     {
         $app['controllers_factory'] = function () use ($app) {
             return new I18nControllerCollection(
@@ -22,11 +23,11 @@ class I18nRoutingServiceProvider implements ServiceProviderInterface
             );
         };
 
-        $app['url_generator'] = $app->share(function ($app) {
+        $app['url_generator'] = function ($app) {
             $app->flush();
 
             return new I18nUrlGenerator($app['routes'], $app['request_context']);
-        });
+        };
 
         $app['i18n_routing.locales'] = array('en');
         $app['i18n_routing.translation_domain'] = 'routes';

--- a/src/Jenyak/I18nRouting/Provider/I18nRoutingServiceProvider.php
+++ b/src/Jenyak/I18nRouting/Provider/I18nRoutingServiceProvider.php
@@ -4,13 +4,12 @@ namespace Jenyak\I18nRouting\Provider;
 
 use Jenyak\I18nRouting\I18nControllerCollection;
 use Jenyak\I18nRouting\I18nUrlGenerator;
-use Pimple\Container;
-use Pimple\ServiceProviderInterface;
 use Silex\Application;
+use Silex\ServiceProviderInterface;
 
 class I18nRoutingServiceProvider implements ServiceProviderInterface
 {
-    public function register(Container $app)
+    public function register(Application $app)
     {
         $app['controllers_factory'] = function () use ($app) {
             return new I18nControllerCollection(
@@ -18,18 +17,20 @@ class I18nRoutingServiceProvider implements ServiceProviderInterface
                 $app['locale'],
                 $app['i18n_routing.locales'],
                 $app['translator'],
-                $app['i18n_routing.translation_domain']
+                $app['i18n_routing.translation_domain'],
+                $app['i18n_routing.allow_localized_default']
             );
         };
 
-        $app['url_generator'] = function ($app) {
+        $app['url_generator'] = $app->share(function ($app) {
             $app->flush();
 
             return new I18nUrlGenerator($app['routes'], $app['request_context']);
-        };
+        });
 
         $app['i18n_routing.locales'] = array('en');
         $app['i18n_routing.translation_domain'] = 'routes';
+        $app['i18n_routing.allow_localized_default'] = false;
     }
 
     public function boot(Application $app)

--- a/tests/I18nRoutingServiceProviderTest.php
+++ b/tests/I18nRoutingServiceProviderTest.php
@@ -22,6 +22,7 @@ class I18nRoutingServiceProviderTest extends \PHPUnit_Framework_TestCase
         $app['translator.domains'] = array('routes' => array(
             'ua' => array('test' => '/тест'),
         ));
+        $app['i18n_routing.allow_localized_default'] = false;
 
         return $app;
     }


### PR DESCRIPTION
In a project, I had to generate every URLs localized, and also the non-localised default locale URL.
I think it's better to let the user a free choice on this point.
To set the option : 

`$app['i18n_routing.allow_localized_default'] = true;`

Let's say I have french and english languages enable.
With the option set to **false**, this will result in the following generated URLs : 

`/fr/test`
`/en/test`

With the option set to **true**, this will result in the following generated URLs : 

`/test`
`/fr/test`
`/en/test`
